### PR TITLE
add docstrings and DocStringExtensions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,14 +1,16 @@
 name = "StochasticStir"
 uuid = "c3541e7a-ece5-4a49-9931-82ce8f5cb0be"
 authors = ["Milan Klöwer <milankloewer@gmx.de> and contributors"]
-version = "0.1"
+version = "0.1.0"
 
 [deps]
+DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 SpeedyWeather = "9e226e20-d153-4fed-8a5b-493def4f21a9"
 
 [compat]
-julia = "1.8"
+DocStringExtensions = "0.9"
 SpeedyWeather = "0.8"
+julia = "1.8"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/StochasticStir.jl
+++ b/src/StochasticStir.jl
@@ -1,6 +1,7 @@
 module StochasticStir
 
 using SpeedyWeather
+using DocStringExtensions
 
 export StochasticStirring, JetDrag
 

--- a/src/jet_drag.jl
+++ b/src/jet_drag.jl
@@ -71,7 +71,7 @@ function SpeedyWeather.drag!(
     time::DateTime,
     model::ModelSetup,
 )
-    SpeedyWeather.drag!(diagn,prog,drag,model.geometry)
+    SpeedyWeather.drag!(diagn,progn,drag,model.geometry)
 end
 
 """

--- a/src/jet_drag.jl
+++ b/src/jet_drag.jl
@@ -1,3 +1,8 @@
+"""
+Defines the JetDrag drag term for SpeedyWeather that applies
+a zonal drag to the BarotropicModel or ShallowWaterModel following
+a jet at specified latitude, strength and width with time scale time_scale.
+$(TYPEDFIELDS)"""
 Base.@kwdef struct JetDrag{NF} <: SpeedyWeather.AbstractDrag{NF}
 
     # DIMENSIONS from SpectralGrid
@@ -22,42 +27,74 @@ Base.@kwdef struct JetDrag{NF} <: SpeedyWeather.AbstractDrag{NF}
     ζ₀::LowerTriangularMatrix{Complex{NF}} = zeros(LowerTriangularMatrix{Complex{NF}},trunc+2,trunc+1)
 end
 
+"""
+$(TYPEDSIGNATURES)
+Generator function of a JetDrag struct taking resolution and number format from 
+a SpectralGrid. Other options are provided as keyword arguments."""
 function JetDrag(SG::SpectralGrid;kwargs...)
     return JetDrag{SG.NF}(;SG.trunc,kwargs...)
 end
 
+"""
+$(TYPEDSIGNATURES)
+Extends the initialize! function for a JetDrag. Precomputes the zonal velocity
+of the jet, transforms to spectral and takes the curl to get the corresponding
+relative vorticity of the jet, which is used to apply the drag to the vorticity
+equation."""
 function SpeedyWeather.initialize!( drag::JetDrag,
                                     model::ModelSetup)
 
     (;spectral_grid, geometry) = model
     (;Grid,NF,nlat_half) = spectral_grid
+    lat = geometry.latds        # latitude in ˚N for every grid point
+
+    # zonal velocity of the jet, allocate following grid and number format NF of model
     u = zeros(Grid{NF},nlat_half)
 
-    lat = geometry.latds
-
+    # Gaussian in latitude, calculated for every grid point ij
     for ij in eachindex(u)
         u[ij] = drag.u₀ * exp(-(lat[ij]-drag.latitude)^2/(2*drag.width^2))
     end
 
+    # to spectral space of size lmax+1 × mmax as required by the curl 
     û = SpeedyTransforms.spectral(u,one_more_degree=true)
     v̂ = zero(û)
     SpeedyTransforms.curl!(drag.ζ₀,û,v̂,model.spectral_transform)
     return nothing
 end
 
-function SpeedyWeather.drag!(   diagn::DiagnosticVariablesLayer,
-                                progn::PrognosticVariablesLayer,
-                                drag::JetDrag,
-                                time::DateTime,
-                                model::ModelSetup)
+# function barrier to unpack only what's needed
+function SpeedyWeather.drag!( 
+    diagn::DiagnosticVariablesLayer,
+    progn::PrognosticVariablesLayer,
+    drag::JetDrag,
+    time::DateTime,
+    model::ModelSetup,
+)
+    SpeedyWeather.drag!(diagn,prog,drag,model.geometry)
+end
 
+"""
+$(TYPEDSIGNATURES)
+Extends the drag! function for JetDrag. Adds the -r*(ζ-ζ₀) term
+to the vorticity tendency.
+"""
+function SpeedyWeather.drag!(
+    diagn::DiagnosticVariablesLayer,
+    progn::PrognosticVariablesLayer,
+    drag::JetDrag,
+    geometry::Geometry,
+)
     (;vor) = progn
     (;vor_tend) = diagn.tendencies
     (;ζ₀) = drag
     
-    (;radius) = model.spectral_grid
+    # 1/time_scale [1/s] but scaled with radius as is the vorticity equation
+    (;radius) = geometry
     r = radius/drag.time_scale.value
-    for lm in eachindex(vor,vor_tend,ζ₀)
+
+    # add the -r*(ζ-ζ₀) term to the vorticity tendency that already includes the forcing term
+    @inbounds for lm in eachindex(vor,vor_tend,ζ₀)
         vor_tend[lm] -= r*(vor[lm] - ζ₀[lm])
     end
 end


### PR DESCRIPTION
@KristianJS I've added `DocStringExtensions` that makes it really easy to document the code. E.g. I write

```julia
"""
$(TYPEDSIGNATURE)
And some text explaining this function.
"""
function f(x) = x
```
and calling the help via `?` of this function would automatically replace `$(TYPEDSIGNATURES)` with the function signature (and their types). In our case this means

```julia
julia> using StochasticStir

help?> StochasticStirring
search: StochasticStirring StochasticStir

  A SpeedyWeather forcing term that stochastically stirrs relative vorticity in the
  BarotropicModel or the ShallowWaterModel.

    •  trunc::Int64: Spectral resolution as max degree of spherical harmonics

    •  nlat::Int64: Number of latitude rings, used for latitudinal mask

    •  decorrelation_time::Dates.Second: Decorrelation time scale τ [days]

    •  strength::Float64: Stirring strength A [1/s²]

    •  latitude::Float64: Stirring latitude [˚N]

    •  width::Float64: Stirring width [˚]

    •  lmin::Int64: Minimum degree of spherical harmonics to force

    •  lmax::Int64: Maximum degree of spherical harmonics to force

    •  mmin::Int64: Minimum order of spherical harmonics to force

    •  mmax::Int64: Maximum order of spherical harmonics to force

    •  S::SpeedyWeather.LowerTriangularMatrices.LowerTriangularMatrix{Complex{NF}} where NF:
       Stochastic stirring term S

    •  a::Base.RefValue: a = A*sqrt(1 - exp(-2dt/τ)), the noise factor times the stirring
       strength [1/s²]

    •  b::Base.RefValue: b = exp(-dt/τ), the auto-regressive factor [1]

    •  lat_mask::Vector: Latitudinal mask, confined to mid-latitude storm track by default
       [1]

  ────────────────────────────────────────────────────────────────────────────────────────────────

  StochasticStirring(
      SG::SpeedyWeather.SpectralGrid;
      kwargs...
  ) -> StochasticStirring{<:AbstractFloat}


  Generator function for StochasticStirring using resolution and number format from a
  SpectralGrid. Further options should be provided as keyword arguments.

julia>
```
Even though I wrote only the short sentences, the rest is inserted automatically.

At the moment it's not easy to see which are the actual options and which are other fields/parameters needed but that are automatically chosen. We can probably change that if needed, but it's already a big step towards self documenting code.