### PR TITLE
mask=true/false for StochasticStirring, JetDrag initialization with model.spectral_transform

### DIFF
--- a/src/jet_drag.jl
+++ b/src/jet_drag.jl
@@ -56,8 +56,8 @@ function SpeedyWeather.initialize!( drag::JetDrag,
         u[ij] = drag.u₀ * exp(-(lat[ij]-drag.latitude)^2/(2*drag.width^2))
     end
 
-    # to spectral space of size lmax+1 × mmax as required by the curl 
-    û = SpeedyTransforms.spectral(u, one_more_degree=true)
+    # to spectral space, reusing the precomputed spectral transform from model
+    û = SpeedyTransforms.spectral(u, model.spectral_transform)
     v̂ = zero(û)
     SpeedyTransforms.curl!(drag.ζ₀, û, v̂, model.spectral_transform)
     return nothing

--- a/src/stochastic_stirring.jl
+++ b/src/stochastic_stirring.jl
@@ -138,6 +138,9 @@ function SpeedyWeather.forcing!(
         end
     end
 
+    # add stochastic stirring term S to vorticity tendency
+    # with masked or without (=skip additional transform)
+    (; vor_tend) = diagn.tendencies
     if forcing.mask
         # to grid-point space
         S_grid = diagn.dynamics_variables.a_grid        # reuse general work array
@@ -147,7 +150,6 @@ function SpeedyWeather.forcing!(
         RingGrids._scale_lat!(S_grid, forcing.lat_mask)
         
         # back to spectral space, write directly into vorticity tendency
-        (; vor_tend) = diagn.tendencies
         SpeedyTransforms.spectral!(vor_tend, S_grid, spectral_transform)
     else
         vor_tend .= S   # copy forcing S over into vor_tend

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,8 +40,9 @@ end
 @testset "Mask off" begin
     spectral_grid = SpectralGrid(trunc=31, nlev=1)
     drag = JetDrag(spectral_grid, time_scale=Day(6))
-    
     forcing = StochasticStirring(spectral_grid, mask=false)
+    initial_conditions = StartFromRest()
+
     model = BarotropicModel(;spectral_grid, initial_conditions, forcing, drag)
     simulation = initialize!(model)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,3 +23,28 @@ using Test
     run!(simulation, period=Day(5))
     @test simulation.model.feedback.nars_detected == false
 end
+
+@testset "Initialize at various resolutions" begin
+    for trunc in (31, 42, 63, 85, 127, 170, 255, 340)
+        spectral_grid = SpectralGrid(trunc=trunc, nlev=1)
+        drag = JetDrag(spectral_grid, time_scale=Day(6))
+        forcing = StochasticStirring(spectral_grid)
+        initial_conditions = StartFromRest()
+    
+        # with barotropic model
+        model = BarotropicModel(;spectral_grid, initial_conditions, forcing, drag)
+        simulation = initialize!(model)
+    end
+end
+
+@testset "Mask off" begin
+    spectral_grid = SpectralGrid(trunc=31, nlev=1)
+    drag = JetDrag(spectral_grid, time_scale=Day(6))
+    
+    forcing = StochasticStirring(spectral_grid, mask=false)
+    model = BarotropicModel(;spectral_grid, initial_conditions, forcing, drag)
+    simulation = initialize!(model)
+
+    run!(simulation, period=Day(5))
+    @test simulation.model.feedback.nars_detected == false
+end


### PR DESCRIPTION
I hit this error when initialization a T340 JetDrag

```julia
julia> simulation = initialize!(model)
ERROR: BoundsError
Stacktrace:
 [1] _divergence!(kernel::SpeedyWeather.SpeedyTransforms.var"#kernel#35"{…}, div::LowerTriangularMatrix{…}, u::LowerTriangularMatrix{…}, v::LowerTriangularMatrix{…}, S::SpectralTransform{…})
   @ SpeedyWeather.SpeedyTransforms ~/.julia/packages/SpeedyWeather/hY1td/src/SpeedyTransforms/spectral_gradients.jl:55
 [2] #curl!#34
   @ ~/.julia/packages/SpeedyWeather/hY1td/src/SpeedyTransforms/spectral_gradients.jl:19 [inlined]
 [3] curl!(curl::LowerTriangularMatrix{…}, u::LowerTriangularMatrix{…}, v::LowerTriangularMatrix{…}, S::SpectralTransform{…})
   @ SpeedyWeather.SpeedyTransforms ~/.julia/packages/SpeedyWeather/hY1td/src/SpeedyTransforms/spectral_gradients.jl:8
 [4] initialize!(drag::JetDrag{…}, model::BarotropicModel{…})
   @ StochasticStir ~/.julia/packages/StochasticStir/Dp1uV/src/jet_drag.jl:62
 [5] initialize!(model::BarotropicModel{…}; time::DateTime)
   @ SpeedyWeather ~/.julia/packages/SpeedyWeather/hY1td/src/models/barotropic.jl:76
 [6] initialize!(model::BarotropicModel{…})
   @ SpeedyWeather ~/.julia/packages/SpeedyWeather/hY1td/src/models/barotropic.jl:66
 [7] top-level scope
   @ REPL[20]:1
Some type information was truncated. Use `show(err)` to see complete types.
```

So it now reuses `model.spectral_transform` which seems to solve the problem